### PR TITLE
Do not pre-prepare an ownership automatically

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -202,7 +202,7 @@ class ProductOwnershipAdmin(CustomGeoModelAdmin):
 
 class ProductOwnershipInline(admin.TabularInline):
     model = ProductOwnership
-    extra = 1
+    extra = 0
 
 class ProductAdmin(CustomGeoModelAdmin):
     save_as = True


### PR DESCRIPTION
Product ownerships are not mandatory and not used by SITN. 

I suggest to not prepare a form for ownerships in the admin while creating a new product. If the inline form is prepared, it makes it look like it's a mandatory field:

<img width="994" height="485" alt="image" src="https://github.com/user-attachments/assets/ba70944b-0dde-4c10-8f95-4b941f8ff523" />

With this PR, one user can still add ownership if he wants to, but the list is empty by default:

<img width="1528" height="299" alt="image" src="https://github.com/user-attachments/assets/561c7023-223e-469f-8127-8fe9fb6f2342" />
